### PR TITLE
fix failure on killing subprocess

### DIFF
--- a/main.py
+++ b/main.py
@@ -236,8 +236,10 @@ def kill_subprocess(process: subprocess.Popen):
         pass
 
 if __name__ == '__main__':
+    shell = CampusRunShell()
     try:
-        CampusRunShell().cmdloop()
+        shell.cmdloop()
     except KeyboardInterrupt:
         logger.info("\n程序被中断，正在清理... / Program interrupted, cleaning up...")
+        shell.do_cleanup('')
         sys.exit(0)


### PR DESCRIPTION
The two subprocess, tunnel and tunneld service, are not exited correctly after main execution. The fix starts them with subprocess.Popen(..., shell=False) to ensure the pid matches the pid of services, but not cmd.exe. This should fix, but I added function `kill_subprocess` that ensure all childre process of given subprocess.Popen instance is killed properly. The fix hides the session of the two services, if original behavior is preferred (run with `start cmd /k`), this function should be able to kill them (not tested).